### PR TITLE
feat: add deployment secret env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,5 @@ docs/apidocs/static/jquery.scrollTo.min.js
 docs/apidocs/static/scroll.js
 pkg/jx/cmd/verify-pod.log
 
-plugin.gz
+plugin.gz.history
+.history

--- a/charts/jx-build-controller/templates/deployment.yaml
+++ b/charts/jx-build-controller/templates/deployment.yaml
@@ -63,13 +63,9 @@ spec:
             value: {{ $pval }}
 {{- end }}
 {{- if .Values.envSecrets }}
-{{- range $pkey, $pval := .Values.envSecrets }}
-          - name: {{ $pkey }}
-            valueFrom:
-              secretKeyRef:
-                name: jx-build-controller-env
-                key: {{ $pkey }}
-{{- end }}
+          envFrom:
+          - secretRef:
+              name: jx-build-controller-env
 {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/jx-build-controller/templates/deployment.yaml
+++ b/charts/jx-build-controller/templates/deployment.yaml
@@ -62,6 +62,15 @@ spec:
           - name: {{ $pkey }}
             value: {{ $pval }}
 {{- end }}
+{{- if .Values.envSecrets }}
+{{- range $pkey, $pval := .Values.envSecrets }}
+          - name: {{ $pkey }}
+            valueFrom:
+              secretKeyRef:
+                name: jx-build-controller-env
+                key: {{ $pkey }}
+{{- end }}
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/charts/jx-build-controller/templates/env-secret.yaml
+++ b/charts/jx-build-controller/templates/env-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.envSecrets }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: jenkins-x
+  name: jx-build-controller-env
+stringData:
+{{- range $pkey, $pval := .Values.envSecrets }}
+  {{ $pkey }}: {{ quote $pval }}
+{{- end }}
+{{- end }}

--- a/charts/jx-build-controller/values.yaml
+++ b/charts/jx-build-controller/values.yaml
@@ -19,6 +19,17 @@ env:
   GIT_AUTHOR_NAME: "jenkins-x-bot"
   GIT_AUTHOR_EMAIL: "jenkins-x@googlegroups.com"
   XDG_CONFIG_HOME: "/home/jenkins"
+
+# define environment variables that will be stored in a secret namd 'jx-build-controller-env' and populated as env vars on the deployment
+#
+# example
+#
+# envSecrets:
+#   AWS_ACCESS_KEY: xxx
+#   AWS_SECRET_KEY: yyy
+#
+envSecrets: {}
+
 clusterrole:
   enabled: true
   rules:


### PR DESCRIPTION
Add support to the helm chart to define deployment environment variables using a secret. All env secrets will be stored in a secret named jx-build-controller-env

The reason for needing this is to support using minio which as far as I know doesn't support IRSA

To use minio you can configure jx-build-controller like the following :

**buildcontroller-values.yaml**

```
envSecrets:
  AWS_ACCESS_KEY: "some key"
  AWS_SECRET_KEY: "some value"
```

**jx-requirements.yml**

```
storage:
  - name: logs
    url: s3://jx3/logs?endpoint=minio.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored
```