### PR TITLE
fix: prevent jx-build-controller from hanging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jenkins-x-plugins/jx-build-controller
 require (
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/gorilla/mux v1.8.0
-	github.com/jenkins-x-plugins/jx-pipeline v0.5.12
+	github.com/jenkins-x-plugins/jx-pipeline v0.5.13
 	github.com/jenkins-x-plugins/jx-secret v0.3.1
 	github.com/jenkins-x/jx-api/v4 v4.6.2
 	github.com/jenkins-x/jx-helpers/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -978,8 +978,8 @@ github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/U
 github.com/jcmturner/goidentity/v6 v6.0.1/go.mod h1:X1YW3bgtvwAXju7V3LCIMpY0Gbxyjn/mY9zx4tFonSg=
 github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aWNYyvBVK62bc=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/jenkins-x-plugins/jx-pipeline v0.5.12 h1:SUJEEalKFOtwHzpv/N2dgV2LUJ1otNlmOFpgf5ZQ/4Q=
-github.com/jenkins-x-plugins/jx-pipeline v0.5.12/go.mod h1:iJwAbFdC7JJm94+daCjjmcGO50nmxtgnqdOq4SGHdFc=
+github.com/jenkins-x-plugins/jx-pipeline v0.5.13 h1:fuTG0MuwF+Z2rWQBjI3nKrVSzOFt7y5PAwL6l+5NP5U=
+github.com/jenkins-x-plugins/jx-pipeline v0.5.13/go.mod h1:iJwAbFdC7JJm94+daCjjmcGO50nmxtgnqdOq4SGHdFc=
 github.com/jenkins-x-plugins/jx-secret v0.3.1 h1:bnmJYJvrwQ5WxEM5MRvxkjaG9OFLAQP6ZVhQY4p39Zk=
 github.com/jenkins-x-plugins/jx-secret v0.3.1/go.mod h1:2TnnWApp/Mz0ZYS53s6ncDUOeArn2LNtBZamwt+hmgg=
 github.com/jenkins-x/go-scm v1.11.6 h1:nYf4pXkaVRFbLCpr0k6E82s+P+LrNPDUTB4pW35CwoI=


### PR DESCRIPTION
This upgrade prevents jx-build-controller from hanging a when a stage has failed even though no pod has been found. This is typically due to some error in the pipeline, but there are other cases as well. I seem to recall excessive memory consumption of the pipeline leading to quick pod eviction also caused hanging.